### PR TITLE
Update CaffeineCache.java

### DIFF
--- a/layering-cache-core/src/main/java/com/github/xiaolyuh/cache/caffeine/CaffeineCache.java
+++ b/layering-cache-core/src/main/java/com/github/xiaolyuh/cache/caffeine/CaffeineCache.java
@@ -165,6 +165,7 @@ public class CaffeineCache extends AbstractValueAdaptingCache {
         Caffeine<Object, Object> builder = Caffeine.newBuilder();
         builder.initialCapacity(firstCacheSetting.getInitialCapacity());
         builder.maximumSize(firstCacheSetting.getMaximumSize());
+        builder.softValues();
         if (ExpireMode.WRITE.equals(firstCacheSetting.getExpireMode())) {
             builder.expireAfterWrite(firstCacheSetting.getExpireTime(), firstCacheSetting.getTimeUnit());
         } else if (ExpireMode.ACCESS.equals(firstCacheSetting.getExpireMode())) {


### PR DESCRIPTION
caffeine默认使用强引用存储缓存的value.如果缓存的阈值设置的较大,可能会导致触发淘汰策略之前因为内存不足导致OOM.将caffeine的value改为软引用,在内存不足时,GC会尝试回收缓存.之后如果内存还不够才会抛出OOM异常.